### PR TITLE
Remove alpha channel (Caused by Apple Store Review)

### DIFF
--- a/ThemeKit/ThemeKit/Classes/Renditions/TKBitmapRendition.m
+++ b/ThemeKit/ThemeKit/Classes/Renditions/TKBitmapRendition.m
@@ -135,7 +135,11 @@
                                                                  pixelHeight:(unsigned int)self.image.pixelsHigh];
     wrapper.pixelFormat = self.pixelFormat;
     wrapper.allowsMultiPassEncoding = NO;
-    
+
+    // Remove alpha channel (Caused by Apple Store Review)
+    if (self.image.size.width == 1024 && self.image.size.height == 1024) {
+        wrapper.sourceAlphaInfo = 0;
+    }
 
     if (!self.image.isPlanar && self.image.hasAlpha &&
         self.image.bitsPerPixel == 32 && self.image.samplesPerPixel == 4 &&


### PR DESCRIPTION
Fix the following errors

ERROR ITMS-90717: "Invalid App Store Icon. The App Store Icon in the asset catalog in 'aa.app' can't be transparent nor contain an alpha channel."